### PR TITLE
changed names of constants to be compatible to current versions of ffmpeg (2016-01-13)

### DIFF
--- a/ffmpeg_frame.c
+++ b/ffmpeg_frame.c
@@ -499,8 +499,8 @@ int _php_resample_frame(ff_frame_context *ff_frame,
         return 0;
     }
 
-    /* convert to PIX_FMT_YUV420P required for resampling */
-    _php_convert_frame(ff_frame, PIX_FMT_YUV420P);
+    /* convert to AV_PIX_FMT_YUV420P required for resampling */
+    _php_convert_frame(ff_frame, AV_PIX_FMT_YUV420P);
 
     img_resample_ctx = img_resample_full_init(
             wanted_width, wanted_height,
@@ -512,7 +512,7 @@ int _php_resample_frame(ff_frame_context *ff_frame,
     }
 
     resampled_frame = avcodec_alloc_frame();
-    avpicture_alloc((AVPicture*)resampled_frame, PIX_FMT_YUV420P,
+    avpicture_alloc((AVPicture*)resampled_frame, AV_PIX_FMT_YUV420P,
             wanted_width, wanted_height);
 
     img_resample(img_resample_ctx, (AVPicture*)resampled_frame,

--- a/ffmpeg_movie.c
+++ b/ffmpeg_movie.c
@@ -915,7 +915,7 @@ static const char* _php_get_codec_name(ff_movie_context *ffmovie_ctx, int type)
                 codec_name = "mp1";
         }
 #endif
-    } else if (decoder_ctx->codec_id == CODEC_ID_MPEG2TS) {
+    } else if (decoder_ctx->codec_id == AV_CODEC_ID_MPEG2TS) {
         /* fake mpeg2 transport stream codec (currently not registered) */
         codec_name = "mpeg2ts";
     } else if (decoder_ctx->codec_name[0] != '\0') {

--- a/ffmpeg_tools.c
+++ b/ffmpeg_tools.c
@@ -98,8 +98,8 @@ ImgReSampleContext * img_resample_full_init (int owidth, int oheight, int iwidth
     int srcSurface = (iwidth - rightBand - leftBand)* (iheight - topBand - bottomBand);
     // We use bilinear when the source surface is big, and bicubic when the number of pixels to handle is less than 1 MPixels
     s->context = sws_getContext(iwidth - rightBand - leftBand,
-            iheight - topBand - bottomBand, PIX_FMT_YUV420P, owidth, oheight,
-            PIX_FMT_YUV420P, srcSurface > 1024000 ? SWS_FAST_BILINEAR : SWS_BICUBIC,
+            iheight - topBand - bottomBand, AV_PIX_FMT_YUV420P, owidth, oheight,
+            AV_PIX_FMT_YUV420P, srcSurface > 1024000 ? SWS_FAST_BILINEAR : SWS_BICUBIC,
             NULL, NULL, NULL);
     if (s->context == NULL) {
         av_free(s);


### PR DESCRIPTION
fix for `error: 'CODEC_ID_MPEG2TS' undeclared (first use in this function)` and similar
