### PR TITLE
added a fix for `undefined symbol: avcodec_alloc_frame in Unknown on line 0`

### DIFF
--- a/php_ffmpeg.h
+++ b/php_ffmpeg.h
@@ -58,7 +58,10 @@
 #define FFMPEG_PHP_END_METHODS {NULL, NULL, NULL, 0, 0}
 #endif
 
-
+/*
+ * fix for `undefined symbol: avcodec_alloc_frame in Unknown on line 0`
+ */
+#define av_frame_alloc avcodec_alloc_frame
 
 
 #define SAFE_STRING(s) ((s)?(s):"")


### PR DESCRIPTION
It would be better to do a
```c
#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(55,28,1)
#define av_frame_alloc avcodec_alloc_frame
#endif
```
but that threw an error
```
php_ffmpeg.h:61:44: error: missing binary operator before token "("
#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(55,28,1)
```