### PR TITLE
Check for includes in /usr/include/ffmpeg/libav*

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -21,7 +21,12 @@ if test "$PHP_FFMPEG" != "no"; then
 
   AC_MSG_CHECKING(for ffmpeg headers)
   for i in $INC_CHECK_DIRS ; do
-    if test -f $i/include/libavcodec/avcodec.h; then
+    if test -d $i/include/ffmpeg -a -f $i/include/ffmpeg/libavcodec/avcodec.h; then
+      dnl some distros put headers under /usr/include/ffmpeg/libav{codec,...} now
+      FFMPEG_INC_FOUND=$i/include
+      PHP_ADD_INCLUDE($i/include/ffmpeg/)
+      break
+    elif test -f $i/include/libavcodec/avcodec.h; then
       dnl ffmpeg svn revision 12194 and newer put each header in its own dir
       dnl so we have to include them all.
 dnl      PHP_ADD_INCLUDE($i/include/libavcodec/)


### PR DESCRIPTION
Nowadays some distros (e.g. openSUSE/packman and Fedora/RPMFusion) are putting the ffmpeg includes under /usr/include/ffmpeg, e.g. `/usr/include/ffmpeg/libavcodec/avcodec.h`.  Patch configure to find these.

Using pkg-config might be a better/more portable option, since ffmpeg-devel includes pkg-config files, but it's more difficult.  I got a pkg-config version working using `PKG_CHECK_MODULES` and `PHP_ADD_INCLINE`, but only by running `aclocal; autoconf` after `phpize` and before `configure`, as for some reason phpize isn't loading `/usr/share/aclocal/pkg.m4`.  Even that is way further down the autotools rabbit-hole than I ever wished to venture, so I decided to submit the simpler patch instead.
